### PR TITLE
Add custom loggerName capture for Kotest

### DIFF
--- a/logcapture-kotest/src/main/kotlin/com/logcapture/kotest/LogCaptureListener.kt
+++ b/logcapture-kotest/src/main/kotlin/com/logcapture/kotest/LogCaptureListener.kt
@@ -11,14 +11,14 @@ import org.hamcrest.Matcher
 import org.slf4j.Logger.ROOT_LOGGER_NAME
 import org.slf4j.LoggerFactory
 
-object LogCaptureListener : TestListener {
+class LogCaptureListener(private val loggerName: String = ROOT_LOGGER_NAME) : TestListener {
 
   private lateinit var logAppender: StubAppender
   private lateinit var root: Logger
 
   override suspend fun beforeTest(testCase: TestCase) {
     logAppender = StubAppender()
-    root = LoggerFactory.getLogger(ROOT_LOGGER_NAME) as Logger
+    root = LoggerFactory.getLogger(loggerName) as Logger
     root.addAppender(logAppender)
   }
 

--- a/logcapture-kotest/src/test/kotlin/com/logcapture/kotest/LogCaptureListenerWithCustomLoggerNameSpec.kt
+++ b/logcapture-kotest/src/test/kotlin/com/logcapture/kotest/LogCaptureListenerWithCustomLoggerNameSpec.kt
@@ -2,19 +2,21 @@ package com.logcapture.kotest
 
 import com.logcapture.assertion.ExpectedLoggingMessage.aLog
 import io.kotest.core.spec.style.StringSpec
+import org.hamcrest.Matchers.equalTo
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-class LogCaptureListenerSpec : StringSpec({
+class LogCaptureListenerWithCustomLoggerNameSpec : StringSpec({
 
-  val log: Logger = LoggerFactory.getLogger(LogCaptureListenerSpec::class.java)
+  val log: Logger = LoggerFactory.getLogger("CUSTOM-LOGGER")
 
-  val logCaptureListener = LogCaptureListener()
+  val logCaptureListener = LogCaptureListener("CUSTOM-LOGGER")
   listener(logCaptureListener)
 
   "verify log messages" {
     log.info("a message")
 
+    logCaptureListener.logged(aLog().info().withLoggerName(equalTo("CUSTOM-LOGGER")))
     logCaptureListener.logged(aLog().info().withMessage("a message"))
   }
 })


### PR DESCRIPTION
This feature already exists in LogCapture for JUnit, we need this feature for Kotest and we though this update could be useful for your library.