### PR TITLE
Use api to include core, so that users only need 1 dependency

### DIFF
--- a/logcapture-example/build.gradle
+++ b/logcapture-example/build.gradle
@@ -1,6 +1,5 @@
 
 dependencies {
-  implementation "org.logcapture:logcapture-core:1.3.2"
   implementation "org.logcapture:logcapture-junit4:1.3.3"
   implementation "junit:junit:4.13.2"
 }

--- a/logcapture-junit4/build.gradle
+++ b/logcapture-junit4/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation project(":logcapture-core")
+  api project(":logcapture-core")
   implementation "junit:junit:4.13.2"
 
   testImplementation "org.assertj:assertj-core:3.26.3"

--- a/logcapture-junit5/build.gradle
+++ b/logcapture-junit5/build.gradle
@@ -7,7 +7,7 @@ ext {
 }
 
 dependencies {
-  implementation project(":logcapture-core")
+  api project(":logcapture-core")
   implementation "org.junit.jupiter:junit-jupiter-api:$junit5_version"
 
   testImplementation "org.junit.jupiter:junit-jupiter-engine:$junit5_version"

--- a/logcapture-kotest/build.gradle
+++ b/logcapture-kotest/build.gradle
@@ -7,7 +7,7 @@ ext {
 }
 
 dependencies {
-  implementation project(":logcapture-core")
+  api project(":logcapture-core")
 
   implementation "io.kotest:kotest-runner-junit5-jvm:$kotestVersion"
   implementation "io.kotest:kotest-assertions-core-jvm:$kotestVersion"

--- a/logcapture-spock/build.gradle
+++ b/logcapture-spock/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation project(":logcapture-core")
+  api project(":logcapture-core")
 
   implementation 'org.spockframework:spock-core:1.3-groovy-2.5'
 }

--- a/logcapture-spock2/build.gradle
+++ b/logcapture-spock2/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation project(":logcapture-core")
+  api project(":logcapture-core")
 
   implementation 'org.spockframework:spock-core:2.0-groovy-3.0'
 }


### PR DESCRIPTION
Hi @jsalinaspolo,

thank you for this library :+1: 

Currently users need to have 2 dependencies on this lib to use it.
```
    testImplementation("org.logcapture:logcapture-core:1.3.3")
    testImplementation("org.logcapture:logcapture-kotest:1.3.3")
```

Thats due to the specific libs (e.G. kotest) not having an api dependency on core (and thereby not making the core library visible to users. See here for more info: https://docs.gradle.org/current/userguide/dependency_configurations.html#sub:what-are-dependency-configurations).

With this PR applied, the core lib is made visible to users, so that they only need one include, e.G.:

```
    testImplementation("org.logcapture:logcapture-kotest:1.3.4")
```