### PR TITLE
Expose underlying log events of LogCaptureListener

### DIFF
--- a/logcapture-kotest/src/main/kotlin/org/logcapture/kotest/LogCaptureListener.kt
+++ b/logcapture-kotest/src/main/kotlin/org/logcapture/kotest/LogCaptureListener.kt
@@ -33,4 +33,8 @@ class LogCaptureListener(private val loggerName: String = ROOT_LOGGER_NAME) : Te
   fun logged(expectedLoggingMessage: Matcher<List<ILoggingEvent>>, times: Int): LogCapture<Any> {
     return LogCapture<Any>(logAppender.events()).logged(expectedLoggingMessage, times)
   }
+
+  fun logged(): LogCapture<Any> {
+    return LogCapture(logAppender.events())
+  }
 }

--- a/logcapture-kotest/src/test/kotlin/org/logcapture/kotest/LogCaptureListenerSpec.kt
+++ b/logcapture-kotest/src/test/kotlin/org/logcapture/kotest/LogCaptureListenerSpec.kt
@@ -1,7 +1,11 @@
 package org.logcapture.kotest
 
+import ch.qos.logback.classic.Level
 import io.kotest.assertions.timing.eventually
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.inspectors.forOne
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import org.logcapture.assertion.ExpectedLoggingMessage.aLog
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -33,6 +37,15 @@ class LogCaptureListenerSpec : StringSpec({
       i += 1
       logMessageWhenCondition(log, i == 5)
       logCaptureListener.logged(aLog().info().withMessage("a message"))
+    }
+  }
+
+  "verify using kotest assertions" {
+    log.info("a message")
+
+    logCaptureListener.logged().events.forOne {
+      it.level shouldBe Level.INFO
+      it.message shouldContain "message"
     }
   }
 })


### PR DESCRIPTION
I'd like to expose the underlying events for use with kotest assertions.

As it stands, if I want to access the log events I need to use Hamcrest matchers to filter events first.

Given that this is in the kotest module, I think it would be nice to allow the user to do their own filtering using kotest itself.

I have added an example of this in the [LogCaptureListenerSpec](logcapture-kotest/src/test/kotlin/org/logcapture/kotest/LogCaptureListenerSpec.kt).